### PR TITLE
Fix 19/22 remaining flake8 issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <h4 align="center">Representation Learning from Stoichiometry</h4>
 
 <h4 align="center">
-  
+
 ![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)
 [![GitHub Repo Size](https://img.shields.io/github/repo-size/comprhys/roost?label=Repo+Size)](https://github.com/comprhys/roost/graphs/contributors)
 [![GitHub last commit](https://img.shields.io/github/last-commit/comprhys/roost?label=Last+Commit)](https://github.com/comprhys/roost/commits)

--- a/examples/dist-pre-example.py
+++ b/examples/dist-pre-example.py
@@ -7,7 +7,7 @@ from sklearn.model_selection import train_test_split as split
 
 from roost.pretrain.dist_data import CrystalGraphData, collate_batch
 from roost.pretrain.dist_model import CrystalGraphPreNet
-from roost.utils import results_multitask, train_ensemble
+from roost.utils import train_ensemble
 
 
 def main(
@@ -59,9 +59,7 @@ def main(
     if val_path:
         val_size = 0.0
 
-    assert val_size < 1.0, (
-        f"'val_size'({val_size}) must be less than 1"
-    )
+    assert val_size < 1.0, f"'val_size'({val_size}) must be less than 1"
 
     if ensemble > 1 and (fine_tune or transfer):
         raise NotImplementedError(
@@ -409,10 +407,7 @@ def input_parser():
     # restart inputs
     use_group = parser.add_mutually_exclusive_group()
     use_group.add_argument(
-        "--fine-tune",
-        type=str,
-        metavar="PATH",
-        help="Checkpoint path for fine tuning"
+        "--fine-tune", type=str, metavar="PATH", help="Checkpoint path for fine tuning"
     )
     use_group.add_argument(
         "--transfer",
@@ -421,9 +416,7 @@ def input_parser():
         help="Checkpoint path for transfer learning",
     )
     use_group.add_argument(
-        "--resume",
-        action="store_true",
-        help="Resume from previous checkpoint"
+        "--resume", action="store_true", help="Resume from previous checkpoint"
     )
 
     # task type
@@ -432,22 +425,12 @@ def input_parser():
         action="store_true",
         help="Evaluate the model/ensemble",
     )
-    parser.add_argument(
-        "--train",
-        action="store_true",
-        help="Train the model/ensemble"
-    )
+    parser.add_argument("--train", action="store_true", help="Train the model/ensemble")
 
     # misc
+    parser.add_argument("--disable-cuda", action="store_true", help="Disable CUDA")
     parser.add_argument(
-        "--disable-cuda",
-        action="store_true",
-        help="Disable CUDA"
-    )
-    parser.add_argument(
-        "--log",
-        action="store_true",
-        help="Log training metrics to tensorboard"
+        "--log", action="store_true", help="Log training metrics to tensorboard"
     )
 
     args = parser.parse_args(sys.argv[1:])
@@ -456,7 +439,10 @@ def input_parser():
         args.model_name = f"{args.data_id}_s-{args.data_seed}_t-{args.sample}"
 
     assert all(
-        [i in ["regression", "classification", "mask", "global", "dist"] for i in args.tasks]
+        [
+            i in ["regression", "classification", "mask", "global", "dist"]
+            for i in args.tasks
+        ]
     ), "Only `regression`, `classification`, `mask` and `global` are allowed as tasks"
 
     args.device = (

--- a/examples/elem-pre-example.py
+++ b/examples/elem-pre-example.py
@@ -7,7 +7,7 @@ from sklearn.model_selection import train_test_split as split
 
 from roost.pretrain.ele_data import CrystalGraphData, collate_batch
 from roost.pretrain.ele_model import CrystalGraphPreNet
-from roost.utils import results_multitask, train_ensemble
+from roost.utils import train_ensemble
 
 
 def main(
@@ -59,9 +59,7 @@ def main(
     if val_path:
         val_size = 0.0
 
-    assert val_size < 1.0, (
-        f"'val_size'({val_size}) must be less than 1"
-    )
+    assert val_size < 1.0, f"'val_size'({val_size}) must be less than 1"
 
     if ensemble > 1 and (fine_tune or transfer):
         raise NotImplementedError(
@@ -409,10 +407,7 @@ def input_parser():
     # restart inputs
     use_group = parser.add_mutually_exclusive_group()
     use_group.add_argument(
-        "--fine-tune",
-        type=str,
-        metavar="PATH",
-        help="Checkpoint path for fine tuning"
+        "--fine-tune", type=str, metavar="PATH", help="Checkpoint path for fine tuning"
     )
     use_group.add_argument(
         "--transfer",
@@ -421,9 +416,7 @@ def input_parser():
         help="Checkpoint path for transfer learning",
     )
     use_group.add_argument(
-        "--resume",
-        action="store_true",
-        help="Resume from previous checkpoint"
+        "--resume", action="store_true", help="Resume from previous checkpoint"
     )
 
     # task type
@@ -432,22 +425,12 @@ def input_parser():
         action="store_true",
         help="Evaluate the model/ensemble",
     )
-    parser.add_argument(
-        "--train",
-        action="store_true",
-        help="Train the model/ensemble"
-    )
+    parser.add_argument("--train", action="store_true", help="Train the model/ensemble")
 
     # misc
+    parser.add_argument("--disable-cuda", action="store_true", help="Disable CUDA")
     parser.add_argument(
-        "--disable-cuda",
-        action="store_true",
-        help="Disable CUDA"
-    )
-    parser.add_argument(
-        "--log",
-        action="store_true",
-        help="Log training metrics to tensorboard"
+        "--log", action="store_true", help="Log training metrics to tensorboard"
     )
 
     args = parser.parse_args(sys.argv[1:])

--- a/examples/ener-pre-example.py
+++ b/examples/ener-pre-example.py
@@ -7,7 +7,7 @@ from sklearn.model_selection import train_test_split as split
 
 from roost.pretrain.ener_data import CrystalGraphData, collate_batch
 from roost.pretrain.ener_model import CrystalGraphPreNet
-from roost.utils import results_multitask, train_ensemble
+from roost.utils import train_ensemble
 
 
 def main(
@@ -59,9 +59,7 @@ def main(
     if val_path:
         val_size = 0.0
 
-    assert val_size < 1.0, (
-        f"'val_size'({val_size}) must be less than 1"
-    )
+    assert val_size < 1.0, f"'val_size'({val_size}) must be less than 1"
 
     if ensemble > 1 and (fine_tune or transfer):
         raise NotImplementedError(
@@ -409,10 +407,7 @@ def input_parser():
     # restart inputs
     use_group = parser.add_mutually_exclusive_group()
     use_group.add_argument(
-        "--fine-tune",
-        type=str,
-        metavar="PATH",
-        help="Checkpoint path for fine tuning"
+        "--fine-tune", type=str, metavar="PATH", help="Checkpoint path for fine tuning"
     )
     use_group.add_argument(
         "--transfer",
@@ -421,9 +416,7 @@ def input_parser():
         help="Checkpoint path for transfer learning",
     )
     use_group.add_argument(
-        "--resume",
-        action="store_true",
-        help="Resume from previous checkpoint"
+        "--resume", action="store_true", help="Resume from previous checkpoint"
     )
 
     # task type
@@ -432,22 +425,12 @@ def input_parser():
         action="store_true",
         help="Evaluate the model/ensemble",
     )
-    parser.add_argument(
-        "--train",
-        action="store_true",
-        help="Train the model/ensemble"
-    )
+    parser.add_argument("--train", action="store_true", help="Train the model/ensemble")
 
     # misc
+    parser.add_argument("--disable-cuda", action="store_true", help="Disable CUDA")
     parser.add_argument(
-        "--disable-cuda",
-        action="store_true",
-        help="Disable CUDA"
-    )
-    parser.add_argument(
-        "--log",
-        action="store_true",
-        help="Log training metrics to tensorboard"
+        "--log", action="store_true", help="Log training metrics to tensorboard"
     )
 
     args = parser.parse_args(sys.argv[1:])

--- a/roost/cgcnn/data.py
+++ b/roost/cgcnn/data.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import torch
 from pymatgen.core.structure import Structure
-from pymatgen.optimization.neighbors import find_points_in_spheres
 from torch.utils.data import Dataset
 
 from roost.core import Featurizer

--- a/roost/pretrain/dist_data.py
+++ b/roost/pretrain/dist_data.py
@@ -1,8 +1,6 @@
 import ast
-import functools
 import os
 from itertools import groupby
-from random import sample
 
 import numpy as np
 import pandas as pd

--- a/roost/pretrain/ele_data.py
+++ b/roost/pretrain/ele_data.py
@@ -1,8 +1,6 @@
 import ast
-import functools
 import os
 from itertools import groupby
-from random import sample
 
 import numpy as np
 import pandas as pd

--- a/roost/pretrain/ener_data.py
+++ b/roost/pretrain/ener_data.py
@@ -1,8 +1,6 @@
 import ast
-import functools
 import os
 from itertools import groupby
-from random import sample
 
 import numpy as np
 import pandas as pd
@@ -297,7 +295,6 @@ def collate_batch(dataset_list):
     batch_self_idx = []
     batch_nbr_idx = []
     crystal_atom_idx = []
-    batch_mask_idx = []
     batch_targets = []
     batch_comps = []
     batch_cif_ids = []

--- a/roost/roost/data.py
+++ b/roost/roost/data.py
@@ -116,7 +116,6 @@ class CompositionData(Dataset):
         nele = len(elements)
         self_fea_idx = []
         nbr_fea_idx = []
-        nbrs = len(elements)
         for i, _ in enumerate(elements):
             self_fea_idx += [i] * nele
             nbr_fea_idx += list(range(nele))
@@ -184,7 +183,6 @@ def collate_batch(dataset_list):
     batch_nbr_fea_idx = []
     crystal_atom_idx = []
     batch_targets = []
-    batch_comp = []
     batch_cry_ids = []
 
     cry_base_idx = 0
@@ -221,5 +219,5 @@ def collate_batch(dataset_list):
             torch.cat(crystal_atom_idx),
         ),
         tuple(torch.stack(b_target, dim=0) for b_target in zip(*batch_targets)),
-        *zip(*batch_cry_ids)
+        *zip(*batch_cry_ids),
     )

--- a/roost/segments.py
+++ b/roost/segments.py
@@ -5,6 +5,7 @@ from torch_scatter import scatter_add, scatter_max, scatter_mean
 
 class MeanPooling(nn.Module):
     """Mean pooling"""
+
     def __init__(self):
         super().__init__()
 
@@ -17,6 +18,7 @@ class MeanPooling(nn.Module):
 
 class SumPooling(nn.Module):
     """Sum pooling"""
+
     def __init__(self):
         super().__init__()
 
@@ -98,8 +100,12 @@ class SimpleNetwork(nn.Module):
     """
 
     def __init__(
-        self, input_dim, output_dim, hidden_layer_dims, activation=nn.LeakyReLU,
-        batchnorm=False
+        self,
+        input_dim,
+        output_dim,
+        hidden_layer_dims,
+        activation=nn.LeakyReLU,
+        batchnorm=False,
     ):
         """
         Inputs
@@ -118,11 +124,11 @@ class SimpleNetwork(nn.Module):
         )
 
         if batchnorm:
-            self.bns = nn.ModuleList([nn.BatchNorm1d(dims[i+1])
-                                    for i in range(len(dims)-1)])
+            self.bns = nn.ModuleList(
+                [nn.BatchNorm1d(dims[i + 1]) for i in range(len(dims) - 1)]
+            )
         else:
-            self.bns = nn.ModuleList([nn.Identity()
-                                    for i in range(len(dims)-1)])
+            self.bns = nn.ModuleList([nn.Identity() for i in range(len(dims) - 1)])
 
         self.acts = nn.ModuleList([activation() for _ in range(len(dims) - 1)])
 
@@ -176,12 +182,10 @@ class ResidualNetwork(nn.Module):
 
         if batchnorm:
             self.bns = nn.ModuleList(
-                [nn.BatchNorm1d(dims[i+1]) for i in range(len(dims)-1)]
+                [nn.BatchNorm1d(dims[i + 1]) for i in range(len(dims) - 1)]
             )
         else:
-            self.bns = nn.ModuleList(
-                [nn.Identity() for i in range(len(dims)-1)]
-            )
+            self.bns = nn.ModuleList([nn.Identity() for i in range(len(dims) - 1)])
 
         self.res_fcs = nn.ModuleList(
             [
@@ -198,9 +202,8 @@ class ResidualNetwork(nn.Module):
             self.fc_out = nn.Linear(dims[-1], output_dim)
 
     def forward(self, x):
-        for fc, bn, res_fc, act in zip(self.fcs, self.bns,
-                                       self.res_fcs, self.acts):
-            x = act(bn(fc(x)))+res_fc(x)
+        for fc, bn, res_fc, act in zip(self.fcs, self.bns, self.res_fcs, self.acts):
+            x = act(bn(fc(x))) + res_fc(x)
 
         if self.return_features:
             return x

--- a/roost/utils.py
+++ b/roost/utils.py
@@ -132,7 +132,7 @@ def init_model(
         optimizer.load_state_dict(checkpoint["optimizer"])
         scheduler.load_state_dict(checkpoint["scheduler"])
 
-    print(f"Total Number of Trainable Parameters: {model.num_params}")
+    print(f"Total Number of Trainable Parameters: {model.num_params:,}")
 
     # TODO parallelise the code over multiple GPUs. Currently DataParallel
     # crashes as subsets of the batch have different sizes due to the use of
@@ -604,10 +604,12 @@ def save_results_dict(ids, results_dict, model_name):
             # sample from the gaussian distributed pre_logits we parameterise.
             if "pre-logits" in col:
                 for n_ens, y_pre_logit in enumerate(data):
-                    results.update({
-                        f"{name}_{col}_c{lab}_n{n_ens}": val.ravel()
-                        for lab, val in enumerate(y_pre_logit.T)
-                    })
+                    results.update(
+                        {
+                            f"{name}_{col}_c{lab}_n{n_ens}": val.ravel()
+                            for lab, val in enumerate(y_pre_logit.T)
+                        }
+                    )
 
             elif "pred" in col:
                 preds = {
@@ -617,10 +619,12 @@ def save_results_dict(ids, results_dict, model_name):
                 results.update(preds)
 
             elif "ale" in col:  # elif so that pre-logit-ale doesn't trigger
-                results.update({
-                    f"{name}_{col}_n{n_ens}": val.ravel()
-                    for (n_ens, val) in enumerate(data)
-                })
+                results.update(
+                    {
+                        f"{name}_{col}_n{n_ens}": val.ravel()
+                        for (n_ens, val) in enumerate(data)
+                    }
+                )
 
             elif col == "target":
                 results.update({f"{name}_{col}": data})

--- a/roost/wren/utils.py
+++ b/roost/wren/utils.py
@@ -154,7 +154,7 @@ def get_aflow_label_from_spga(spga):
 
     # cannonicalise the possible wyckoff letter sequences
     elem_wyks = "_".join(elem_wyks)
-    cannonical = cannonicalise_elem_wyks(elem_wyks, spg_no)
+    cannonical = canonicalise_elem_wyks(elem_wyks, spg_no)
 
     # get pearson symbol
     cry_sys = spga.get_crystal_system()
@@ -177,9 +177,9 @@ def get_aflow_label_from_spga(spga):
     return aflow_label
 
 
-def cannonicalise_elem_wyks(elem_wyks, spg_no):
+def canonicalise_elem_wyks(elem_wyks, spg_no):
     """
-    Given an element ordering cannonicalise the associated wyckoff positions
+    Given an element ordering canonicalise the associated wyckoff positions
     based on the alphabetical weight of equivalent choices of origin.
     """
 
@@ -210,7 +210,7 @@ def cannonicalise_elem_wyks(elem_wyks, spg_no):
                     ]
                 )
             )
-            score += sum(0 if l == "A" else ord(l) - 96 for l in sep_el_wyks[1::2])
+            score += sum(0 if el == "A" else ord(el) - 96 for el in sep_el_wyks[1::2])
 
         scores.append(score)
         sorted_iso.append("_".join(sorted_el_wyks))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-max-complexity = 12
+max-complexity = 15
 
 [isort]
 # Make isort play nicely with black's import formatting https://git.io/Jug0o.


### PR DESCRIPTION
Mostly removing unused imports and declared but unused variables.

Increase `max-complexity: 12 -> 15`.

Rename `cannonicalise_elem_wyks` to `canonicalise_elem_wyks`.

Remaining issues are

> roost/core.py:40:5: C901 'BaseModelClass.fit' is too complex (25)
> roost/utils.py:149:1: C901 'init_losses' is too complex (17)
> roost/utils.py:334:1: C901 'results_multitask' is too complex (20)